### PR TITLE
restore: English harness content (PR #25 follow-up)

### DIFF
--- a/src/content/sessions/maturity.en.mdx
+++ b/src/content/sessions/maturity.en.mdx
@@ -63,18 +63,43 @@ Harness Design is the design of the **agent operating environment**.
 
 If SDD answers "what must be true?", the harness answers "how do we create a system where the agent can execute, validate, and improve without relying on informal memory?".
 
-A harness can include:
+### A model is not an agent
 
-- persistent instructions such as `AGENTS.md`, `CLAUDE.md`, or `.cursor/rules/`;
-- versioned architecture, product, and domain documentation;
-- spec, PRD, plan, and review templates;
-- tools available to the agent, such as terminal, GitHub, browser, logs, and MCP servers;
-- permission boundaries and human approval points;
-- validation commands, CI, lint, typecheck, tests, and security checks;
-- PR standards, ownership, rollback, and audit practices;
-- learning loops that turn failures into rules, tests, or docs.
+A model responds. An agent tries to complete a task using tools in a loop: it reads context, takes an action, observes the result, and decides the next step.
 
-The goal is not to trap the agent. It is to create rails. Rails do not prevent movement; they make movement predictable.
+The harness is what makes that loop useful in real work. It tells the agent which rules to follow, which tools to use, where to find context, when to ask for approval, and how to prove the work is done.
+
+> **agent = model + harness**
+
+### What goes into a harness?
+
+Think of the harness as the agent's work infrastructure. It is not one tool. It is the system that lets you move from conversation to a validated delivery.
+
+- **Instructions**: files like `AGENTS.md`, rules, and skills that carry commands, standards, and project agreements.
+- **Context**: specs, technical decisions, architecture, product docs, and enough history so the agent is not working in the dark.
+- **Tools**: terminal, Git, browser, GitHub, logs, MCP servers, and other integrations that let the agent act in the right environment.
+- **Boundaries**: sandbox, permissions, human approvals, and blocks for destructive or sensitive actions.
+- **Validation**: lint, tests, typecheck, build, diff review, and checklists that push back against broken delivery.
+- **Learning**: each recurring failure becomes a rule, test, hook, doc, or skill. The harness improves because the team learned.
+
+The goal is not to trap the agent. It is to create rails. Good rails do not prevent movement; they make movement predictable, reviewable, and safe.
+
+### Harness in practice
+
+The difference shows up when a task leaves the prototype stage and enters a real product.
+
+**Without a harness**: someone asks "build the user invite screen." The agent might create a nice screen, but ignore permissions, error states, product copy, responsiveness, tests, and existing design rules.
+
+**With a harness**: the same task, with rails. The agent gets a short spec, UI rules, existing components, acceptance criteria, validation commands, and permission limits. At the end, it must explain what changed and how it tested it.
+
+### A harness in one week
+
+You do not need to build a platform. Start with one real failure and turn learning into structure.
+
+1. **Write a short `AGENTS.md`**: include project commands, important standards, and two or three rules the agent should always respect.
+2. **Document how to validate**: list lint, tests, typecheck, build, and any check that proves a change did not break the basics.
+3. **Pick a recurring failure**: choose a problem that already happened: skipped test, broken UI pattern, wrong file, forgotten command.
+4. **Turn the failure into a rail**: create a rule, test, checklist, hook, or skill. If it happens again, the harness is not clear enough yet.
 
 ## Applied example: enterprise SSO
 

--- a/src/pages/en/harness-engineering.astro
+++ b/src/pages/en/harness-engineering.astro
@@ -6,12 +6,7 @@ import Card from '../../components/Card/Card.astro';
 import Badge from '../../components/Badge/Badge.astro';
 import Footer from '../../components/Footer/Footer.astro';
 import Discussion from '../../components/Discussion/Discussion.astro';
-import {
-  getHarnessAlternateLinks,
-  getProjectHref,
-  getSessionHref,
-  getSkillsHref,
-} from '../../lib/i18n';
+import { getHarnessAlternateLinks, getSessionHref } from '../../lib/i18n';
 
 const lang = 'en';
 const alternateLinks = getHarnessAlternateLinks();
@@ -19,253 +14,798 @@ const maturityHref = getSessionHref(lang, 'maturity');
 ---
 
 <BaseLayout
-  title="Harness Engineering: what it is and how to use it with AI agents"
-  description="An English guide to Harness Engineering: prompts, tools, context, hooks, validation, and boundaries for working better with coding agents."
+  title="Harness Engineering: the layer that turns models into reliable agents"
+  description="The discipline behind the harness: context, tools, execution, validation, security, and feedback loops that make agents operational and trustworthy."
   lang={lang}
   alternateLinks={alternateLinks}
 >
   <main id="main-content" class="harness-page">
+
+    <!-- Hero -->
     <SectionBlock as="header" padding="xl">
-      <Badge variant="coral">Deep dive</Badge>
+      <Badge variant="coral">Fundamentals</Badge>
       <h1 class="page-title">Harness Engineering</h1>
       <p class="page-summary">
-        The operating environment that turns an AI model into an agent that can
-        work with context, boundaries, and validation.
+        The discipline that turns models into operational agents: context,
+        tools, execution, validation, security, and feedback loops.
       </p>
+      <nav class="chapter-nav" aria-label="Chapters">
+        <a href="#fundamentals">Ch. 1 · Fundamentals</a>
+        <a href="#anatomy">Ch. 2 · Anatomy</a>
+        <a href="#maturity">Ch. 3 · Maturity</a>
+        <a href="#governance">Ch. 4 · Governance</a>
+        <a href="#engineer">Ch. 5 · The engineer</a>
+        <a href="#conclusion">Conclusion</a>
+      </nav>
     </SectionBlock>
 
-    <SectionBlock padding="lg" alt>
-      <div class="section-copy">
-        <h2>In 30 seconds</h2>
-        <p class="section-lead">
-          Harness Engineering is the practice of designing everything around an
-          AI agent: instructions, tools, context, permissions, validation, and
-          feedback loops.
-        </p>
-        <p>
-          Without a harness, the agent depends too much on the prompt of the
-          moment. With a harness, the work becomes more predictable, reviewable,
-          and safe. The point is not to freeze the AI. It is to give it rails so
-          it can execute without forgetting what matters.
-        </p>
+    <!-- ═══════════════════════════════════════════════
+         CHAPTER 1 · FUNDAMENTALS
+    ════════════════════════════════════════════════ -->
+    <SectionBlock padding="lg" alt id="fundamentals">
+      <div class="chapter-intro">
+        <Badge variant="yellow">Chapter 1</Badge>
+        <span class="chapter-label">Fundamentals</span>
       </div>
-    </SectionBlock>
+      <div class="section-stack">
 
-    <SectionBlock padding="lg">
-      <div class="intro-grid">
         <div class="section-copy">
           <h2>A model is not an agent</h2>
           <p>
-            A model responds. An agent tries to complete a task using tools in a
-            loop: it reads context, takes an action, observes the result, and
-            decides the next step.
+            For the past few years, most of the conversation about AI in
+            engineering has centered on one simple question:
+            <em>which model writes better code?</em>
           </p>
           <p>
-            The harness is what makes that loop useful in real work. It tells
-            the agent which rules to follow, which tools to use, where to find
-            context, when to ask for approval, and how to prove it is done.
+            The question makes sense, but it is incomplete.
           </p>
-        </div>
-        <div class="equation-card" aria-label="Agent with harness equation">
-          <span>agent</span>
-          <strong>= model + harness</strong>
-        </div>
-      </div>
-    </SectionBlock>
-
-    <SectionBlock padding="lg" alt>
-      <div class="section-stack">
-        <div class="section-copy">
-          <h2>What goes into a harness?</h2>
-          <p class="section-lead">
-            Think of the harness as the agent's work infrastructure. It is not
-            one tool. It is the system that helps the team move from chat to a
-            validated delivery.
+          <p>
+            A model can be excellent at reasoning, code generation, and context
+            interpretation. Even so, on its own it remains a statistical function
+            that takes input and produces output. It has no persistent state by
+            default. It does not know which commands it can run. It does not know
+            which files it can change. It does not know when to stop. It does not
+            know which tests are mandatory. It does not know which changes are
+            dangerous. It does not know what has already been validated.
           </p>
+          <p>
+            To turn a model into an agent, we need to surround it with
+            infrastructure: tools, permissions, memory, context, tests,
+            validators, sandbox, logs, security policies, workflows, human
+            review, and feedback mechanisms.
+          </p>
+          <p>That layer is the harness.</p>
         </div>
 
-        <Grid columns={3} gap="lg" align="stretch">
-          <Card title="Instructions" accent="yellow">
-            <p>
-              Files like <code>AGENTS.md</code>, rules, and skills that carry
-              commands, standards, and project agreements.
-            </p>
-          </Card>
-          <Card title="Context" accent="blue">
-            <p>
-              Specs, technical decisions, architecture, product docs, and enough
-              history so the agent is not working in the dark.
-            </p>
-          </Card>
-          <Card title="Tools" accent="green">
-            <p>
-              Terminal, Git, browser, GitHub, logs, MCP servers, and other
-              integrations that let the agent act in the right environment.
-            </p>
-          </Card>
-          <Card title="Boundaries" accent="coral">
-            <p>
-              Sandbox, permissions, human approvals, and blocks for destructive
-              or sensitive actions.
-            </p>
-          </Card>
-          <Card title="Validation" accent="yellow">
-            <p>
-              Lint, tests, typecheck, build, diff review, and checklists that
-              push back against broken delivery.
-            </p>
-          </Card>
-          <Card title="Learning" accent="blue">
-            <p>
-              Each recurring failure becomes a rule, test, hook, doc, or skill.
-              The harness improves because the team learned.
-            </p>
-          </Card>
-        </Grid>
-      </div>
-    </SectionBlock>
+        <div class="equation-card" aria-label="The real agent equation">
+          <span>The real agent is not the isolated model.</span>
+          <strong>
+            agent = model + context + tools + state + permissions +
+            validation + execution loop
+          </strong>
+          <span class="equation-caption">
+            Harness Engineering is the practice of designing that system.
+          </span>
+        </div>
 
-    <SectionBlock padding="lg">
-      <div class="section-stack">
         <div class="section-copy">
-          <h2>A practical example</h2>
+          <h2>What a harness is</h2>
           <p class="section-lead">
-            The difference shows up when a task leaves the prototype stage and
-            enters a real product.
+            A harness is the software layer that lets a model act on a real
+            environment without relying solely on a natural-language response.
+          </p>
+          <p>In a coding agent, the harness can include:</p>
+          <ul class="brutal-list">
+            <li>repository access and file read/write;</li>
+            <li>terminal and test execution;</li>
+            <li>static analysis, lint, and typecheck;</li>
+            <li>runtime logs and decision history;</li>
+            <li>project rules and scoped permissions;</li>
+            <li>pull request workflows and human review;</li>
+            <li>rollback mechanisms.</li>
+          </ul>
+        </div>
+
+        <div class="contrast-card">
+          <div class="contrast-side weak">
+            <Badge variant="coral">Without a harness</Badge>
+            <p>The model only <strong>suggests</strong>.</p>
+          </div>
+          <div class="contrast-arrow" aria-hidden="true">→</div>
+          <div class="contrast-side strong">
+            <Badge variant="green">With a harness</Badge>
+            <p>
+              The agent can <strong>observe, modify, execute, verify, and
+              correct</strong>.
+            </p>
+          </div>
+        </div>
+
+        <blockquote class="key-insight">
+          A response can look correct. An execution must prove it is correct
+          inside a specific environment.
+        </blockquote>
+
+        <div class="section-copy">
+          <h2>Why harness matters more than prompt</h2>
+          <p>
+            Prompt engineering was important because it taught us to structure
+            intent. But software agents need more than well-written intent.
+            They need <strong>operational control</strong>.
           </p>
         </div>
 
         <div class="comparison-grid">
           <article class="comparison-card weak">
-            <Badge variant="coral">Without a harness</Badge>
-            <h3>"Build the user invite screen"</h3>
-            <p>
-              The agent might create a nice screen, but ignore permissions,
-              error states, product copy, responsiveness, tests, and existing
-              design rules.
-            </p>
+            <Badge variant="coral">Prompt</Badge>
+            <h3>"implement this feature with tests"</h3>
+            <p>Guides the model. Leaves everything else open.</p>
           </article>
-
           <article class="comparison-card strong">
-            <Badge variant="green">With a harness</Badge>
-            <h3>The same task, with rails</h3>
-            <p>
-              The agent gets a short spec, UI rules, existing components,
-              acceptance criteria, validation commands, and permission limits.
-              At the end, it must explain what changed and how it tested it.
-            </p>
+            <Badge variant="green">Harness</Badge>
+            <h3>Defines the execution environment</h3>
+            <ul class="brutal-list compact">
+              <li>which files are relevant;</li>
+              <li>which repository patterns to follow;</li>
+              <li>which commands validate the change;</li>
+              <li>which areas are off-limits;</li>
+              <li>when to ask for approval;</li>
+              <li>which evidence proves the task is done;</li>
+              <li>how to log failures to improve the system.</li>
+            </ul>
           </article>
         </div>
+
+        <blockquote class="key-insight">
+          A prompt guides the model. A harness governs the agent. The natural
+          evolution is not from prompt engineering to longer prompts. It is
+          from prompt engineering to Harness Engineering.
+        </blockquote>
+
       </div>
     </SectionBlock>
 
-    <SectionBlock padding="lg" alt id="start-small">
+    <!-- ═══════════════════════════════════════════════
+         CHAPTER 2 · ANATOMY
+    ════════════════════════════════════════════════ -->
+    <SectionBlock padding="lg" id="anatomy">
+      <div class="chapter-intro">
+        <Badge variant="blue">Chapter 2</Badge>
+        <span class="chapter-label">The anatomy of the harness</span>
+      </div>
       <div class="section-stack">
+
         <div class="section-copy">
-          <Badge variant="green">Start small</Badge>
-          <h2 class="section-title">A harness in one week</h2>
+          <h2>Code as part of the harness</h2>
           <p class="section-lead">
-            You do not need to build a platform. Start with one real failure and
-            turn learning into structure.
+            In modern agentic systems, code is not just the output an agent
+            produces. Code can also be the medium through which the agent
+            thinks, acts, observes the world, maintains state, and verifies
+            progress.
+          </p>
+          <p>
+            This is deeper than "AI that writes code." The core idea is that
+            code becomes part of the agent's own runtime: it creates scripts,
+            tests, validators, traces, and executable plans that are not just
+            outputs — they are part of the work process itself.
           </p>
         </div>
 
-        <ol class="step-list">
-          <li class="step-card">
-            <span class="step-number">1</span>
+        <Grid columns={3} gap="lg" align="stretch">
+          <Card title="Reasoning substrate" accent="yellow">
+            <p>
+              The agent externalizes thinking into executable code. Instead of
+              inferring whether something works, it writes a script, runs it
+              against real examples, and compares the result.
+            </p>
+          </Card>
+          <Card title="Action interface" accent="blue">
+            <p>
+              Code is the bridge between intent and actual change in the
+              environment: editing files, calling APIs, running commands,
+              opening pull requests.
+            </p>
+          </Card>
+          <Card title="Environment model" accent="green">
+            <p>
+              The harness makes the repository, logs, errors, and conventions
+              inspectable, reducing the gap between what the agent thinks the
+              system is and what it actually is.
+            </p>
+          </Card>
+          <Card title="Verification mechanism" accent="coral">
+            <p>
+              Tests, lint, typecheck, and build prove that behavior is correct.
+              The harness shifts trust from "confidence in the model" to
+              "evidence generated by execution."
+            </p>
+          </Card>
+          <Card title="Operational memory" accent="yellow">
+            <p>
+              Scripts, traces, and executable plans record state between
+              sessions: decisions made, paths discarded, active constraints.
+            </p>
+          </Card>
+          <Card title="Shared artifact" accent="blue">
+            <p>
+              In multi-agent systems, code is the common collaboration substrate.
+              Agents coordinate through verifiable artifacts, not just messages.
+            </p>
+          </Card>
+        </Grid>
+
+        <div class="section-copy">
+          <h2>The three layers of the harness</h2>
+          <p class="section-lead">
+            The harness can be understood as three progressive layers, each
+            built on top of the previous one.
+          </p>
+        </div>
+
+        <!-- Layer 1: Interface -->
+        <div class="layer-block">
+          <div class="layer-header">
+            <span class="layer-number">1</span>
             <div>
-              <h3>Write a short <code>AGENTS.md</code></h3>
-              <p>
-                Include project commands, important standards, and two or three
-                rules the agent should always respect.
+              <h3>Interface layer</h3>
+              <p class="layer-desc">
+                The interface between the model and the environment. Here code
+                turns intent into something executable.
               </p>
             </div>
+          </div>
+          <div class="layer-points">
+            <div class="layer-point">
+              <h4>Code to reason</h4>
+              <p>
+                Natural language is ambiguous. Code is more constrained: it can
+                be run, it can fail, it can be tested. When an agent uses code
+                to reason, it externalizes part of its thinking into a
+                verifiable form.
+              </p>
+            </div>
+            <div class="layer-point">
+              <h4>Code to act</h4>
+              <p>
+                A mature coding agent should not just reply with a diff. It
+                should operate inside a controlled cycle: understand the
+                goal → inspect the environment → propose a plan → change only
+                what is needed → run validation → fix if it fails → present
+                evidence.
+              </p>
+              <p>That sequence depends on a harness.</p>
+            </div>
+            <div class="layer-point">
+              <h4>Code to model the environment</h4>
+              <p>
+                An agent's environment is not just the prompt. It is the
+                repository, file tree, tests, logs, errors, CI, API contracts,
+                dependencies, and prior decisions.
+              </p>
+              <p>
+                Many agent failures happen because they work with an imagined
+                version of the system. A good harness reduces that gap.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Layer 2: Mechanisms -->
+        <div class="layer-block">
+          <div class="layer-header">
+            <span class="layer-number">2</span>
+            <div>
+              <h3>Mechanism layer</h3>
+              <p class="layer-desc">
+                The mechanisms that let the agent operate reliably. This is
+                where Harness Engineering becomes most practical.
+              </p>
+            </div>
+          </div>
+          <div class="layer-points">
+            <div class="layer-point">
+              <h4>Planning as an operational contract</h4>
+              <p>
+                In a mature harness, the plan acts as a contract. It makes
+                clear what will change, why, which files will be touched, which
+                risks exist, which validations will run, and which evidence
+                defines success.
+              </p>
+              <p>
+                The plan is not just for organizing thought. It is for
+                controlling execution. If the agent deviates from the plan, the
+                harness can detect it.
+              </p>
+            </div>
+            <div class="layer-point">
+              <h4>Memory and context</h4>
+              <p>
+                Agents fail when they lose state: they forget decisions, repeat
+                mistakes, confuse old requirements with current ones, ignore
+                constraints that no longer fit in the active context.
+              </p>
+              <p>
+                Useful memory is operational state: architectural decisions,
+                validation commands, repository patterns, recurring failures,
+                security constraints, acceptance criteria. Context engineering
+                is a core discipline here — not adding more to the prompt, but
+                putting the right information in at the right time.
+              </p>
+            </div>
+            <div class="layer-point">
+              <h4>Governed tools</h4>
+              <p>
+                Tools expand the agent's action surface, but ungoverned tools
+                increase risk. Harness Engineering treats tools as governed
+                interfaces with clear scope, explicit permission, interpretable
+                return values, usage limits, and error policies.
+              </p>
+              <p>
+                The question is not "what tools does the agent have?" The better
+                question is: what actions can the agent take, under what
+                conditions, with what evidence, and with what reversibility?
+              </p>
+            </div>
+            <div class="layer-point">
+              <h4>The Plan-Execute-Verify loop</h4>
+              <p>
+                The core of a reliable harness is the loop:
+                <strong>plan → execute → verify → revise</strong>.
+              </p>
+              <p>
+                With a harness, the agent produces a change, executes it in a
+                controlled environment, observes real feedback, and decides
+                whether to accept, fix, escalate, or roll back. Verification
+                uses deterministic sensors: tests, typecheck, lint, build,
+                static analysis, logs, contracts, and security policies.
+              </p>
+              <blockquote>
+                The harness makes uncertainty visible. It reduces reliance on
+                subjective trust and increases the amount of operational evidence.
+              </blockquote>
+            </div>
+          </div>
+        </div>
+
+        <!-- Layer 3: Scale -->
+        <div class="layer-block">
+          <div class="layer-header">
+            <span class="layer-number">3</span>
+            <div>
+              <h3>Scale layer</h3>
+              <p class="layer-desc">
+                When we move into multi-agent systems, the harness becomes even
+                more important.
+              </p>
+            </div>
+          </div>
+          <div class="scale-grid">
+            <div class="section-copy">
+              <p>
+                Two or more agents should not collaborate only through
+                conversation. Conversation is volatile, easy to lose state
+                from, and hard to audit. Reliable multi-agent work needs a
+                shared substrate: repository, branch, issue, pull request,
+                versioned plan, test, trace, log, shared memory, task board,
+                review workflow, or interface contract.
+              </p>
+              <p>
+                Collaboration between agents should happen over verifiable
+                artifacts, not just over messages.
+              </p>
+            </div>
+            <div class="scale-cards">
+              <article class="comparison-card weak">
+                <Badge variant="coral">Without a harness</Badge>
+                <h3>Multi-agent becomes theater</h3>
+                <p>
+                  Multiple characters talking, little guarantee of real
+                  progress.
+                </p>
+              </article>
+              <article class="comparison-card strong">
+                <Badge variant="green">With a harness</Badge>
+                <h3>Multi-agent becomes a system</h3>
+                <p>
+                  Specialized roles, shared state, common validation, and an
+                  auditable trail.
+                </p>
+              </article>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </SectionBlock>
+
+    <!-- ═══════════════════════════════════════════════
+         CHAPTER 3 · MATURITY
+    ════════════════════════════════════════════════ -->
+    <SectionBlock padding="lg" alt id="maturity">
+      <div class="chapter-intro">
+        <Badge variant="green">Chapter 3</Badge>
+        <span class="chapter-label">Maturity</span>
+      </div>
+      <div class="section-stack">
+
+        <div class="section-copy">
+          <h2>The common mistake: treating the harness as a wrapper</h2>
+          <p>
+            It is tempting to think of the harness as a thin layer around the
+            model. A bit of prompt. Some tools. An instructions file. Maybe a
+            test script. That is a start, but it is not enough.
+          </p>
+          <p>
+            <strong>A harness is not packaging. A harness is operational
+            infrastructure.</strong>
+          </p>
+          <p>
+            When a failure happens, the mature question is not just "did the
+            model make a mistake?" The mature question is:
+            <em>did the harness allow this failure?</em>
+          </p>
+          <p>
+            Maybe the agent lacked sufficient context. Maybe the right test
+            did not exist. Maybe the tool returned an ambiguous signal. Maybe
+            the plan had no acceptance criteria. Maybe the permission was too
+            broad. Maybe this failure had already happened before but never
+            became a memory, test, or rule.
+          </p>
+          <blockquote class="key-insight">
+            Harness Engineering turns failures into structural improvement.
+            Every failure should leave the system better: a new rule, a new
+            test, a new check, a tighter permission boundary, an operational
+            memory entry.
+          </blockquote>
+
+          <h2>Evaluating the model is not enough</h2>
+          <p>
+            We still compare agents superficially: "that model is better than
+            this one." But in real systems, performance does not come from the
+            model alone. It comes from the whole system: context quality,
+            environment access, available tools, execution ability, test
+            quality, permission policy, memory, error recovery, human review,
+            telemetry, and workflow design.
+          </p>
+          <p>
+            Two teams can use the same model and get completely different
+            results. The difference is the harness.
+          </p>
+          <blockquote class="key-insight">
+            The most relevant question is not "which model do you use?" It is:
+            <em>how does your harness turn intent into validated change?</em>
+          </blockquote>
+
+          <h2>Five maturity levels</h2>
+          <p>
+            A weak harness depends on trust in the output. A strong harness
+            creates a controlled cycle of change, validation, learning, and
+            governance.
+          </p>
+        </div>
+
+        <ol class="maturity-list">
+          <li class="maturity-card">
+            <div class="maturity-header">
+              <span class="maturity-number">1</span>
+              <h3>Response</h3>
+            </div>
+            <p>
+              The model replies with instructions or code. No execution. No
+              validation. The human must interpret everything.
+            </p>
           </li>
-          <li class="step-card">
-            <span class="step-number">2</span>
-            <div>
-              <h3>Document how to validate</h3>
-              <p>
-                List lint, tests, typecheck, build, and any check that proves a
-                change did not break the basics.
-              </p>
+          <li class="maturity-card">
+            <div class="maturity-header">
+              <span class="maturity-number">2</span>
+              <h3>Assisted action</h3>
             </div>
+            <p>
+              The agent edits files or suggests diffs. Still heavily dependent
+              on the human to know whether it worked.
+            </p>
           </li>
-          <li class="step-card">
-            <span class="step-number">3</span>
-            <div>
-              <h3>Pick a recurring failure</h3>
-              <p>
-                Choose a problem that already happened: skipped test, broken UI
-                pattern, wrong file, forgotten command.
-              </p>
+          <li class="maturity-card">
+            <div class="maturity-header">
+              <span class="maturity-number">3</span>
+              <h3>Validated execution</h3>
             </div>
+            <p>
+              The agent changes files, runs tests, reads errors, and corrects.
+              This is where real agentic behavior begins.
+            </p>
           </li>
-          <li class="step-card">
-            <span class="step-number">4</span>
-            <div>
-              <h3>Turn the failure into a rail</h3>
-              <p>
-                Create a rule, test, checklist, hook, or skill. If it happens
-                again, the harness is not clear enough yet.
-              </p>
+          <li class="maturity-card">
+            <div class="maturity-header">
+              <span class="maturity-number">4</span>
+              <h3>Governed workflow</h3>
             </div>
+            <p>
+              The agent operates with permissions, acceptance criteria, logs,
+              rollback, review, and risk policies. The system becomes part of
+              the engineering process.
+            </p>
+          </li>
+          <li class="maturity-card maturity-card--peak">
+            <div class="maturity-header">
+              <span class="maturity-number">5</span>
+              <h3>Evolving harness</h3>
+            </div>
+            <p>
+              The system learns from failures, improves its rules, adds
+              verifiers, records operational memory, and reduces regressions
+              over time. The harness becomes an organizational asset.
+            </p>
           </li>
         </ol>
+
       </div>
     </SectionBlock>
 
-    <SectionBlock padding="xl">
-      <div class="next-grid">
+    <!-- ═══════════════════════════════════════════════
+         CHAPTER 4 · GOVERNANCE AND SECURITY
+    ════════════════════════════════════════════════ -->
+    <SectionBlock padding="lg" id="governance">
+      <div class="chapter-intro">
+        <Badge variant="coral">Chapter 4</Badge>
+        <span class="chapter-label">Governance and security</span>
+      </div>
+      <div class="section-stack">
+
         <div class="section-copy">
-          <Badge variant="blue">Next step</Badge>
-          <h2 class="section-title">Now connect harness to delivery</h2>
+          <h2>Human-in-the-loop is not an approval button</h2>
           <p>
-            Harness Engineering gets stronger when it works with SDD, skills,
-            and a real project. Use these paths to go deeper without losing the
-            thread.
+            Many teams treat human review as a pause in the flow. The agent
+            does something risky, then asks for approval. That is better than
+            nothing, but it is still shallow.
+          </p>
+          <p>
+            In a mature harness, human-in-the-loop is part of the system state.
+            Human review must record what was approved, by whom, with what
+            context, with what evidence, with what known risks, with what
+            permission scope, and for how long the decision stands.
+          </p>
+          <blockquote class="key-insight">
+            Approval without context becomes ritual. Approval with evidence
+            becomes governance.
+          </blockquote>
+
+          <h2>Security starts in the harness design</h2>
+          <p>
+            Agents amplify capability. That also amplifies the risk surface.
+            An agent can leak a secret, delete a file, run a destructive
+            command, call the wrong API, change critical behavior without
+            enough tests, or follow a malicious instruction hidden inside
+            documentation, an issue, a comment, or a web page.
+          </p>
+          <p>
+            You cannot fix this by asking the agent to "be careful" in the
+            prompt. Security must be in the harness.
           </p>
         </div>
 
-        <div class="link-stack">
-          <Card
-            title="Session 3: SDD and Harness Design"
-            href={maturityHref}
-            accent="blue"
-          >
+        <Grid columns={3} gap="lg" align="stretch">
+          <Card title="Isolation" accent="coral">
+            <p>Isolated environments and minimum permissions per scope.</p>
+          </Card>
+          <Card title="Action control" accent="yellow">
             <p>
-              Understand the professional workflow that combines spec, agent,
-              and validation.
+              Blocking irreversible actions and mandatory review for sensitive
+              operations.
             </p>
           </Card>
-          <Card
-            title="Skills for agents"
-            href={getSkillsHref(lang)}
-            accent="green"
-          >
-            <p>See how to package reusable process for your harness.</p>
+          <Card title="Traceability" accent="blue">
+            <p>
+              Audit trail of commands and a log of every action the agent
+              executes.
+            </p>
           </Card>
-          <Card
-            title="Hands-on Project"
-            href={getProjectHref(lang)}
-            accent="yellow"
-          >
-            <p>Practice the workflow by creating and publishing a project.</p>
+          <Card title="Data protection" accent="green">
+            <p>Scoped credentials and clear policies for sensitive data.</p>
           </Card>
+          <Card title="Detection" accent="coral">
+            <p>
+              Prompt injection detection and separation of read, write, and
+              execute permissions.
+            </p>
+          </Card>
+          <Card title="Reversibility" accent="yellow">
+            <p>Rollback available for any change applied to the system.</p>
+          </Card>
+        </Grid>
+
+        <blockquote class="key-insight">
+          The more autonomous the agent, the more explicit the harness must be.
+          Autonomy without a harness is not maturity. It is exposure.
+        </blockquote>
+
+      </div>
+    </SectionBlock>
+
+    <!-- ═══════════════════════════════════════════════
+         CHAPTER 5 · THE ENGINEER
+    ════════════════════════════════════════════════ -->
+    <SectionBlock padding="lg" alt id="engineer">
+      <div class="chapter-intro">
+        <Badge variant="blue">Chapter 5</Badge>
+        <span class="chapter-label">The engineer</span>
+      </div>
+      <div class="section-stack">
+
+        <div class="section-copy">
+          <h2>Harness Engineering and AI-native engineering</h2>
+          <p>
+            AI-native engineering is not using AI inside the old process. It is
+            redesigning the process assuming agents can participate in the
+            execution of work.
+          </p>
+          <p>That requires new questions:</p>
+          <ul class="brutal-list">
+            <li>How do we describe intent in an operational form?</li>
+            <li>How does the agent discover relevant context?</li>
+            <li>How does it plan changes?</li>
+            <li>How does it execute safely?</li>
+            <li>How does it verify its own work?</li>
+            <li>How do humans review with evidence?</li>
+            <li>How do learnings become permanent improvements?</li>
+            <li>How do multiple agents share state?</li>
+            <li>How do we measure system quality, not just output quality?</li>
+          </ul>
+          <p>
+            These questions do not belong only to prompt engineering. They
+            belong to a broader discipline. Harness Engineering is that
+            discipline.
+          </p>
+
+          <h2>The engineer's new role</h2>
+          <p>
+            In this landscape, the engineer does not disappear. They move up a
+            level of abstraction.
+          </p>
+          <p>
+            Part of the work is still writing and reviewing code. But a growing
+            part is designing the system where code is produced, validated, and
+            sustained. We did not stop programming when frameworks, cloud,
+            CI/CD, or DevOps arrived — but the level where most of the work
+            happens shifted.
+          </p>
+          <p>
+            With agents, the shift is similar. Quality no longer depends only
+            on the code we write. It also depends on the harness that lets
+            humans and agents work on the same system with safety and evidence.
+          </p>
+        </div>
+
+        <div class="section-copy">
+          <h2>Ten questions for a good harness</h2>
+          <p>
+            A harness does not need to be complex from day one. But it must be
+            explicit. A healthy initial version should answer these ten
+            questions:
+          </p>
+        </div>
+
+        <ol class="questions-list">
+          <li class="question-card">
+            <span class="question-number">1</span>
+            <p>What is the source of truth for the system?</p>
+          </li>
+          <li class="question-card">
+            <span class="question-number">2</span>
+            <p>Which files, logs, and documents can the agent consult?</p>
+          </li>
+          <li class="question-card">
+            <span class="question-number">3</span>
+            <p>Which actions can it take on its own?</p>
+          </li>
+          <li class="question-card">
+            <span class="question-number">4</span>
+            <p>Which actions require approval?</p>
+          </li>
+          <li class="question-card">
+            <span class="question-number">5</span>
+            <p>Which commands validate a change?</p>
+          </li>
+          <li class="question-card">
+            <span class="question-number">6</span>
+            <p>Which criteria define success?</p>
+          </li>
+          <li class="question-card">
+            <span class="question-number">7</span>
+            <p>How are errors recorded?</p>
+          </li>
+          <li class="question-card">
+            <span class="question-number">8</span>
+            <p>How do learnings become rules, tests, or memory?</p>
+          </li>
+          <li class="question-card">
+            <span class="question-number">9</span>
+            <p>How do humans review with sufficient evidence?</p>
+          </li>
+          <li class="question-card">
+            <span class="question-number">10</span>
+            <p>How does the system avoid repeating the same failure?</p>
+          </li>
+        </ol>
+
+      </div>
+    </SectionBlock>
+
+    <!-- ═══════════════════════════════════════════════
+         CONCLUSION
+    ════════════════════════════════════════════════ -->
+    <SectionBlock padding="xl" id="conclusion">
+      <div class="section-stack">
+        <div class="section-copy">
+          <h2>The central thesis</h2>
+          <blockquote class="thesis">
+            It is not enough to have a capable model. You need a system capable
+            of turning capability into reliable work.
+          </blockquote>
+          <p>
+            Models will keep improving. They will reason better, write better,
+            plan better, and handle larger contexts. But that does not remove
+            the need for a harness. Quite the opposite: the more capable models
+            become, the more important it is to have the infrastructure that
+            defines how they can act.
+          </p>
+          <p>
+            The future of AI-assisted engineering will not be decided only by
+            who has access to the best model. It will be decided by who knows
+            how to design the best work systems around those models — systems
+            with clear state, safe execution, objective validation, useful
+            memory, well-positioned human review, and continuous learning.
+          </p>
+
+          <h2>Conclusion</h2>
+          <blockquote class="thesis">
+            Harness Engineering is the practice of turning models into
+            operational agents through context, tools, state, execution,
+            validation, security, and feedback loops.
+          </blockquote>
+          <blockquote class="thesis secondary">
+            Harness Engineering is how we make working with agents less magical
+            and more engineerable.
+          </blockquote>
+          <p>
+            The age of agents does not only call for better prompts. It calls
+            for better systems. And those systems need to be executable,
+            verifiable, and stateful from the design stage.
+          </p>
+          <p>
+            It is not about asking an AI to write code. It is about designing
+            the environment where agents can work well.
+          </p>
         </div>
       </div>
     </SectionBlock>
 
+    <!-- Reference + next step -->
     <SectionBlock padding="lg" alt>
-      <div class="section-copy">
-        <h2>Main reference</h2>
-        <p>
-          This page is inspired by
-          <a href="https://addyosmani.com/blog/agent-harness-engineering/">
-            Agent Harness Engineering
-          </a>, by Addy Osmani, and adapts the concept for this guide's
-          audience.
-        </p>
+      <div class="footer-grid">
+        <div class="section-copy">
+          <h2>Reference</h2>
+          <p>
+            This article is based on
+            <a
+              href="https://arxiv.org/abs/2605.18747"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Code as Agent Harness: Toward Executable, Verifiable, and
+              Stateful Agent Systems
+            </a>
+            and adapts its ideas for this guide's audience.
+          </p>
+        </div>
+        <div class="section-copy">
+          <h2>Keep reading</h2>
+          <p>
+            See how SDD and Harness Design combine into a complete professional
+            workflow in
+            <a href={maturityHref}>Session 3: SDD and Harness Design</a>.
+          </p>
+        </div>
       </div>
     </SectionBlock>
 
@@ -280,91 +820,175 @@ const maturityHref = getSessionHref(lang, 'maturity');
 </BaseLayout>
 
 <style>
+  /* ── Base ──────────────────────────────────────── */
   .page-title {
     margin-top: var(--space-md);
     max-width: 12ch;
   }
 
-  .page-summary,
-  .section-lead {
-    color: var(--color-text-muted);
-    line-height: var(--leading-relaxed);
-  }
-
   .page-summary {
     font-size: var(--text-xl);
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
     margin-top: var(--space-md);
     max-width: 58ch;
   }
 
-  .section-title {
-    margin-top: var(--space-sm);
-  }
-
-  .section-stack,
-  .section-copy {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
+  .section-lead {
+    font-size: var(--text-lg);
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+    max-width: 64ch;
+    margin: 0;
   }
 
   .section-stack {
+    display: flex;
+    flex-direction: column;
     gap: var(--space-xl);
   }
 
   .section-copy {
+    display: flex;
+    flex-direction: column;
     gap: var(--space-md);
     max-width: 74ch;
   }
 
   .section-copy h2,
-  .section-copy p {
+  .section-copy h3,
+  .section-copy p,
+  .section-copy ul,
+  .section-copy ol {
     margin: 0;
   }
 
-  .section-lead {
-    font-size: var(--text-lg);
-    max-width: 64ch;
+  /* ── Chapter nav in hero ───────────────────────── */
+  .chapter-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    margin-top: var(--space-lg);
   }
 
-  .intro-grid,
-  .comparison-grid,
-  .next-grid {
-    display: grid;
-    gap: var(--space-xl);
+  .chapter-nav a {
+    font-size: var(--text-sm);
+    font-family: var(--font-heading);
+    font-weight: var(--weight-bold);
+    color: var(--color-text-muted);
+    text-decoration: none;
+    border: var(--border-thin);
+    border-radius: var(--radius-sm);
+    padding: var(--space-xs) var(--space-sm);
+    transition: color 0.15s, border-color 0.15s;
+  }
+
+  .chapter-nav a:hover {
+    color: var(--color-ink);
+    border-color: var(--color-ink);
+  }
+
+  /* ── Chapter intro ─────────────────────────────── */
+  .chapter-intro {
+    display: flex;
     align-items: center;
-    min-width: 0;
+    gap: var(--space-sm);
   }
 
-  .equation-card,
-  .comparison-card,
-  .step-card {
+  .chapter-label {
+    font-family: var(--font-heading);
+    font-weight: var(--weight-bold);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  /* ── Equation card ─────────────────────────────── */
+  .equation-card {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-xl);
+    border: var(--border-thick);
+    border-top-color: var(--color-accent-1);
+    border-radius: var(--radius-md);
+    background: var(--color-white);
+    box-shadow: var(--shadow-md);
+    font-family: var(--font-heading);
+  }
+
+  .equation-card span {
+    font-size: var(--text-md);
+    color: var(--color-text-muted);
+  }
+
+  .equation-card strong {
+    font-size: var(--text-xl);
+    line-height: var(--leading-tight);
+  }
+
+  .equation-caption {
+    font-size: var(--text-sm) !important;
+    font-style: italic;
+  }
+
+  /* ── Contrast card ─────────────────────────────── */
+  .contrast-card {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: center;
+    gap: var(--space-md);
+    padding: var(--space-lg);
     border: var(--border-thick);
     border-radius: var(--radius-md);
     background: var(--color-white);
     box-shadow: var(--shadow-md);
   }
 
-  .equation-card {
-    display: grid;
+  .contrast-side {
+    display: flex;
+    flex-direction: column;
     gap: var(--space-sm);
-    padding: var(--space-xl);
-    border-top-color: var(--color-accent-1);
-    font-family: var(--font-heading);
   }
 
-  .equation-card span {
-    font-size: var(--text-xl);
+  .contrast-side p {
     color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+    margin: 0;
   }
 
-  .equation-card strong {
-    font-size: var(--text-3xl);
-    line-height: var(--leading-tight);
+  .contrast-arrow {
+    font-size: var(--text-2xl);
+    font-weight: var(--weight-bold);
+    color: var(--color-text-muted);
+    text-align: center;
+  }
+
+  /* ── Key insight blockquote ────────────────────── */
+  .key-insight {
+    border-left: 4px solid var(--color-accent-1);
+    padding: var(--space-md) var(--space-lg);
+    margin: 0;
+    background: var(--color-surface-alt);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    font-style: italic;
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+    max-width: 74ch;
+  }
+
+  /* ── Comparison grid ───────────────────────────── */
+  .comparison-grid {
+    display: grid;
+    gap: var(--space-lg);
   }
 
   .comparison-card {
     padding: var(--space-lg);
+    border: var(--border-thick);
+    border-radius: var(--radius-md);
+    background: var(--color-white);
+    box-shadow: var(--shadow-md);
   }
 
   .comparison-card.weak {
@@ -377,46 +1001,50 @@ const maturityHref = getSessionHref(lang, 'maturity');
 
   .comparison-card h3 {
     margin-block: var(--space-md);
-    font-size: var(--text-2xl);
+    font-size: var(--text-xl);
   }
 
   .comparison-card p,
-  :global(.harness-page .card p),
-  .step-card p,
+  .comparison-card ul {
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+    margin: 0;
+  }
+
+  /* ── Brutal list ───────────────────────────────── */
   .brutal-list {
+    display: grid;
+    gap: var(--space-xs);
+    padding-left: var(--space-lg);
+    margin: 0;
     color: var(--color-text-muted);
     line-height: var(--leading-relaxed);
   }
 
-  :global(.harness-page .card p) {
-    margin: 0;
+  .brutal-list.compact {
+    font-size: var(--text-sm);
   }
 
-  .brutal-list {
-    display: grid;
-    gap: var(--space-sm);
-    max-width: 74ch;
-    padding-left: var(--space-lg);
-    margin: 0;
+  /* ── Layer blocks ──────────────────────────────── */
+  .layer-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+    padding: var(--space-xl);
+    border: var(--border-thick);
+    border-radius: var(--radius-md);
+    background: var(--color-white);
+    box-shadow: var(--shadow-md);
   }
 
-  .step-list {
-    display: grid;
-    gap: var(--space-md);
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .step-card {
+  .layer-header {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr);
     gap: var(--space-md);
     align-items: start;
-    padding: var(--space-lg);
   }
 
-  .step-number {
+  .layer-number {
     display: inline-grid;
     place-items: center;
     width: 2.5rem;
@@ -429,32 +1057,226 @@ const maturityHref = getSessionHref(lang, 'maturity');
     font-size: var(--text-xl);
     font-weight: var(--weight-bold);
     line-height: 1;
+    flex-shrink: 0;
   }
 
-  .step-card h3 {
+  .layer-header h3 {
+    margin: 0 0 var(--space-xs);
+    font-size: var(--text-2xl);
+  }
+
+  .layer-desc {
+    margin: 0;
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+  }
+
+  .layer-points {
+    display: grid;
+    gap: var(--space-lg);
+    padding-top: var(--space-md);
+    border-top: var(--border-thin);
+  }
+
+  .layer-point {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .layer-point h4 {
+    margin: 0;
+    font-size: var(--text-lg);
+  }
+
+  .layer-point p {
+    margin: 0;
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+  }
+
+  .layer-point blockquote {
+    border-left: 3px solid var(--color-accent-1);
+    padding-left: var(--space-md);
+    margin: 0;
+    font-style: italic;
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+  }
+
+  /* ── Scale (multi-agent) ───────────────────────── */
+  .scale-grid {
+    display: grid;
+    gap: var(--space-xl);
+  }
+
+  .scale-cards {
+    display: grid;
+    gap: var(--space-md);
+  }
+
+  /* ── Maturity levels ───────────────────────────── */
+  .maturity-list {
+    display: grid;
+    gap: var(--space-md);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .maturity-card {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: var(--space-md);
+    align-items: start;
+    padding: var(--space-lg);
+    border: var(--border-thick);
+    border-radius: var(--radius-md);
+    background: var(--color-white);
+    box-shadow: var(--shadow-md);
+  }
+
+  .maturity-card--peak {
+    border-top-color: var(--color-accent-3);
+  }
+
+  .maturity-header {
+    display: contents;
+  }
+
+  .maturity-number {
+    display: inline-grid;
+    place-items: center;
+    width: 2.5rem;
+    aspect-ratio: 1;
+    border: var(--border-thick);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-ink);
+    color: var(--color-fg-on-ink);
+    font-family: var(--font-heading);
+    font-size: var(--text-xl);
+    font-weight: var(--weight-bold);
+    line-height: 1;
+    align-self: start;
+  }
+
+  .maturity-card h3 {
     margin: 0 0 var(--space-sm);
     font-size: var(--text-xl);
   }
 
-  .step-card p {
+  .maturity-card p {
+    margin: 0;
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+    grid-column: 2;
+  }
+
+  /* ── 10 questions ──────────────────────────────── */
+  .questions-list {
+    display: grid;
+    gap: var(--space-sm);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .question-card {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: var(--space-md);
+    align-items: center;
+    padding: var(--space-md) var(--space-lg);
+    border: var(--border-thick);
+    border-radius: var(--radius-md);
+    background: var(--color-white);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .question-number {
+    display: inline-grid;
+    place-items: center;
+    width: 2rem;
+    aspect-ratio: 1;
+    border: var(--border-thick);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-accent-1);
+    color: var(--color-fg-on-yellow);
+    font-family: var(--font-heading);
+    font-size: var(--text-md);
+    font-weight: var(--weight-bold);
+    line-height: 1;
+    flex-shrink: 0;
+  }
+
+  .question-card p {
+    margin: 0;
+    font-size: var(--text-md);
+    line-height: var(--leading-relaxed);
+  }
+
+  /* ── Thesis blockquote ─────────────────────────── */
+  .thesis {
+    border-left: 4px solid var(--color-ink);
+    padding: var(--space-lg) var(--space-xl);
+    margin: 0;
+    background: var(--color-ink);
+    color: var(--color-fg-on-ink);
+    border-radius: var(--radius-md);
+    font-family: var(--font-heading);
+    font-size: var(--text-xl);
+    font-style: normal;
+    font-weight: var(--weight-bold);
+    line-height: var(--leading-relaxed);
+  }
+
+  .thesis.secondary {
+    background: var(--color-surface-alt);
+    color: var(--color-ink);
+    border-left-color: var(--color-accent-1);
+  }
+
+  /* ── Footer grid ───────────────────────────────── */
+  .footer-grid {
+    display: grid;
+    gap: var(--space-xl);
+  }
+
+  .footer-grid a {
+    color: var(--color-ink);
+    font-weight: var(--weight-bold);
+  }
+
+  /* ── Card prose ─────────────────────────────────── */
+  :global(.harness-page .card p) {
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
     margin: 0;
   }
 
-  .link-stack {
-    display: grid;
-    gap: var(--space-md);
-    min-width: 0;
+  /* ── Responsive ────────────────────────────────── */
+  @media (min-width: 768px) {
+    .comparison-grid {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    .scale-grid {
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      align-items: start;
+    }
+
+    .footer-grid {
+      grid-template-columns: 1fr 1fr;
+    }
   }
 
-  code {
-    font-family: var(--font-mono);
-  }
+  @media (min-width: 1024px) {
+    .layer-points {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 
-  @media (min-width: 900px) {
-    .intro-grid,
-    .comparison-grid,
-    .next-grid {
-      grid-template-columns: minmax(0, 1fr) minmax(320px, 0.9fr);
+    .questions-list {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 </style>


### PR DESCRIPTION
## Summary
Completes the recovery of [PR #25](https://github.com/baltazarparra/ai-native-engineering/pull/25) by restoring the English locale changes that were on `claude/harness-content-migration-xV2Yl` but not included in PR #26.

Cherry-picked commit `f1d7768`:
- `/en/harness-engineering` — full 5-chapter rewrite (mirrors PT-BR)
- `maturity.en.mdx` — expanded Harness Design section (mirrors `maturidade.mdx`)

## Test plan
- [ ] `pnpm run lint`
- [ ] `pnpm run build`
- [ ] Review `/en/harness-engineering/`
- [ ] Review `/en/sessions/maturity/` harness section
- [ ] CI green before merge


Made with [Cursor](https://cursor.com)