### PR TITLE
docs: PR discipline policy and agent skills registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,50 @@ npm run format     # Prettier
 
 Deploy: GitHub Actions → GitHub Pages (auto-deploy on push to main).
 
+## PR discipline
+
+Keep each **pull request** small enough to review, revert, and merge safely. This matches the phased delivery style in `ROADMAP.md` and `BLOG-ROADMAP.md`.
+
+**Policy**
+
+- At most **400 changed lines per PR** (insertions + deletions combined), measured as `git diff <base>...HEAD` on paths **outside** `src/content/**`
+- Applies to code, layouts, components, config, styles, and data files outside editorial content
+- **Does not apply** to PRs that only touch `src/content/**` (session MDX, blog Markdown, references JSON). Those may exceed 400 lines in a dedicated content-only PR
+- **Mixed PRs** (code + content): only non-`src/content/**` paths count toward the 400-line cap; prefer splitting into a code PR and a content PR when either side would exceed the limit
+- **Commits** inside a PR should still be logical and bisect-friendly, but there is **no per-commit line cap**
+- Prefer lockfiles (`package-lock.json`, `pnpm-lock.yaml`) in their own PR when practical
+
+**When a PR would exceed the limit**
+
+- Split into stacked or independent PRs (for example: schema, then layout, then routes), not one giant PR with many small commits
+- Use branch-per-phase on top of the previous merge, or a split-to-PRs workflow before opening the PR
+- Do not bundle unrelated refactors with feature work
+- Content-only changes under `src/content/**` may stay in their own PR regardless of size
+
+**Enforcement**
+
+- Documented policy only; there is no pre-merge hook or CI check yet. Follow the rule by convention until automation is added.
+- Before opening a PR, check size against the base branch:
+
+```bash
+git diff upstream/main...HEAD --shortstat -- . ':(exclude)src/content'
+```
+
+Adjust `upstream/main` to the real base branch.
+
+## Agent Skills
+
+Project skills live under `.cursor/skills/` and `skills/`. Invoke by name when you need a specific workflow.
+
+| Skill | Path | When to use |
+| --- | --- | --- |
+| `analisar` | `.cursor/skills/analisar/SKILL.md` | Before implementation: analyze a plan `.md` (scope, repo state, locked decisions). Invoke with `/analisar`. Read-only — no code until explicitly requested. |
+| `planejar` | `.cursor/skills/planejar/SKILL.md` | Before implementation: tactical dev plan for the current roadmap phase (files, sequence, risks, validation). Invoke with `/planejar`. Read-only — no code until explicitly requested. |
+| `executar` | `.cursor/skills/executar/SKILL.md` | During implementation: review the phase plan, implement, validate, and hand off. Invoke with `/executar`. |
+| `quality-gate` | `skills/quality-gate/SKILL.md` | After code edits: run lint, build, and other checks before handoff. Runs inside `/executar` Step 3 (Validate). |
+
+Suggested order for phased work: `/analisar` (optional) → `/planejar` → `/executar` → `quality-gate`.
+
 ## Tech Stack & Architecture
 
 **Astro + TypeScript + MDX + React islands + CSS Modules**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,50 @@ npm run format     # Prettier
 
 Deploy: GitHub Actions → GitHub Pages (auto-deploy on push to main).
 
+## PR discipline
+
+Keep each **pull request** small enough to review, revert, and merge safely. This matches the phased delivery style in `ROADMAP.md` and `BLOG-ROADMAP.md`.
+
+**Policy**
+
+- At most **400 changed lines per PR** (insertions + deletions combined), measured as `git diff <base>...HEAD` on paths **outside** `src/content/**`
+- Applies to code, layouts, components, config, styles, and data files outside editorial content
+- **Does not apply** to PRs that only touch `src/content/**` (session MDX, blog Markdown, references JSON). Those may exceed 400 lines in a dedicated content-only PR
+- **Mixed PRs** (code + content): only non-`src/content/**` paths count toward the 400-line cap; prefer splitting into a code PR and a content PR when either side would exceed the limit
+- **Commits** inside a PR should still be logical and bisect-friendly, but there is **no per-commit line cap**
+- Prefer lockfiles (`package-lock.json`, `pnpm-lock.yaml`) in their own PR when practical
+
+**When a PR would exceed the limit**
+
+- Split into stacked or independent PRs (for example: schema, then layout, then routes), not one giant PR with many small commits
+- Use branch-per-phase on top of the previous merge, or a split-to-PRs workflow before opening the PR
+- Do not bundle unrelated refactors with feature work
+- Content-only changes under `src/content/**` may stay in their own PR regardless of size
+
+**Enforcement**
+
+- Documented policy only; there is no pre-merge hook or CI check yet. Follow the rule by convention until automation is added.
+- Before opening a PR, check size against the base branch:
+
+```bash
+git diff upstream/main...HEAD --shortstat -- . ':(exclude)src/content'
+```
+
+Adjust `upstream/main` to the real base branch.
+
+## Agent Skills
+
+Project skills live under `.cursor/skills/` and `skills/`. Invoke by name when you need a specific workflow.
+
+| Skill | Path | When to use |
+| --- | --- | --- |
+| `analisar` | `.cursor/skills/analisar/SKILL.md` | Before implementation: analyze a plan `.md` (scope, repo state, locked decisions). Invoke with `/analisar`. Read-only — no code until explicitly requested. |
+| `planejar` | `.cursor/skills/planejar/SKILL.md` | Before implementation: tactical dev plan for the current roadmap phase (files, sequence, risks, validation). Invoke with `/planejar`. Read-only — no code until explicitly requested. |
+| `executar` | `.cursor/skills/executar/SKILL.md` | During implementation: review the phase plan, implement, validate, and hand off. Invoke with `/executar`. |
+| `quality-gate` | `skills/quality-gate/SKILL.md` | After code edits: run lint, build, and other checks before handoff. Runs inside `/executar` Step 3 (Validate). |
+
+Suggested order for phased work: `/analisar` (optional) → `/planejar` → `/executar` → `quality-gate`.
+
 ## Tech Stack & Architecture
 
 **Astro + TypeScript + MDX + React islands + CSS Modules**

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Contributions are welcome — whether it's suggesting new content, fixing inaccu
 - **Report issues or suggest content:** [open an issue](https://github.com/baltazarparra/ai-native-engineering/issues)
 - **Start a conversation:** [join the discussions](https://github.com/baltazarparra/ai-native-engineering/discussions)
 - **Submit changes:** fork the repo, make your edits, and open a pull request
-- **Keep commits reviewable:** code and config changes should stay under **400 changed lines** per commit (insertions + deletions). Editorial files under `src/content/` are exempt. See [AGENTS.md](AGENTS.md) → Commit Discipline for the full policy.
+- **Keep PRs reviewable:** code and config changes should stay under **400 changed lines** per pull request (insertions + deletions), measured against the PR base branch and excluding `src/content/`. Editorial-only PRs under `src/content/` are exempt. See [AGENTS.md](AGENTS.md) → PR discipline for the full policy.
 
 ## License
 


### PR DESCRIPTION
Adds PR discipline (400 lines per PR) and Agent Skills table in AGENTS/CLAUDE. README contributing note updated.

Made with [Cursor](https://cursor.com)