### PR TITLE
feat(blog): phase 8 EN routes and hreflang

### DIFF
--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const { lang = 'pt-BR' } = Astro.props;
-const blogHref = getBlogHref('pt-BR');
+const blogHref = getBlogHref(lang);
 ---
 
 <!-- Phase 6 discovery: footer + home entry points to /blog/ (BLOG-ROADMAP) -->

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -4,7 +4,7 @@ import SectionBlock from '../components/SectionBlock/SectionBlock.astro';
 import Badge from '../components/Badge/Badge.astro';
 import Footer from '../components/Footer/Footer.astro';
 import Breadcrumbs from '../components/Breadcrumbs/Breadcrumbs.astro';
-import type { Lang } from '../lib/i18n';
+import type { AlternateLink, Lang } from '../lib/i18n';
 import { languages, ui, getHomeHref, getBlogHref } from '../lib/i18n';
 
 interface Props {
@@ -15,6 +15,7 @@ interface Props {
   publishedAt: Date;
   updatedAt?: Date;
   tags: string[];
+  alternateLinks?: AlternateLink[];
 }
 
 const {
@@ -24,6 +25,7 @@ const {
   publishedAt,
   updatedAt,
   tags,
+  alternateLinks = [],
 } = Astro.props;
 
 const labels = ui[lang];
@@ -53,7 +55,7 @@ const breadcrumbItems = [
   title={`${title} | AI-Native Engineers`}
   description={description}
   lang={lang}
-  alternateLinks={[]}
+  alternateLinks={alternateLinks}
 >
   <main id="main-content" class="blog-page">
     <SectionBlock as="header" padding="xl">

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,5 +1,11 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
-import type { Lang } from './i18n';
+import type { AlternateLink, Lang } from './i18n';
+import {
+  defaultLang,
+  getBlogHref,
+  getBlogIndexAlternateLinks,
+  supportedLangs,
+} from './i18n';
 
 export type BlogEntry = CollectionEntry<'blog'>;
 
@@ -23,4 +29,76 @@ export async function getPostBySlug(
   );
   if (!post || post.data.draft) return undefined;
   return post;
+}
+
+export async function getPostByTranslationKey(
+  lang: Lang,
+  translationKey: string,
+): Promise<BlogEntry | undefined> {
+  const posts = await getCollection('blog');
+  const post = posts.find(
+    (entry) =>
+      entry.data.lang === lang &&
+      entry.data.translationKey === translationKey &&
+      !entry.data.draft,
+  );
+  return post;
+}
+
+export async function getBlogAlternateLinks(
+  translationKey: string,
+): Promise<AlternateLink[]> {
+  const links: AlternateLink[] = [];
+
+  for (const lang of supportedLangs) {
+    const post = await getPostByTranslationKey(lang, translationKey);
+    if (post) {
+      links.push({ lang, href: getBlogHref(lang, post.data.slug) });
+    }
+  }
+
+  const defaultPost = await getPostByTranslationKey(
+    defaultLang,
+    translationKey,
+  );
+
+  if (defaultPost) {
+    links.push({
+      lang: 'x-default',
+      href: getBlogHref(defaultLang, defaultPost.data.slug),
+    });
+  }
+
+  return links;
+}
+
+export async function getBlogPostAlternateLinks(
+  post: BlogEntry,
+): Promise<AlternateLink[]> {
+  const indexLinks = getBlogIndexAlternateLinks();
+
+  if (!post.data.translationKey) {
+    return indexLinks;
+  }
+
+  const pairLinks = await getBlogAlternateLinks(post.data.translationKey);
+  const pairByLang = new Map(
+    pairLinks
+      .filter((link): link is AlternateLink & { lang: Lang } =>
+        supportedLangs.includes(link.lang as Lang),
+      )
+      .map((link) => [link.lang, link.href]),
+  );
+
+  return indexLinks.map((link) => {
+    if (link.lang === 'x-default') {
+      return {
+        ...link,
+        href: pairByLang.get(defaultLang) ?? link.href,
+      };
+    }
+
+    const postHref = pairByLang.get(link.lang as Lang);
+    return postHref ? { ...link, href: postHref } : link;
+  });
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -103,7 +103,7 @@ export const ui = {
       title: 'Blog',
       breadcrumb: 'Blog',
       summary:
-        'Artigos sobre engenharia com agentes de código — práticos, diretos, sem hype.',
+        'Artigos sobre engenharia com agentes de código: práticos, diretos, sem hype.',
       emptyState: 'Nenhum post publicado ainda. Volte em breve.',
       cardCta: 'Ler post',
       homeCta: 'Ver artigos',
@@ -249,7 +249,7 @@ export const ui = {
       title: 'Blog',
       breadcrumb: 'Blog',
       summary:
-        'Articles on engineering with code agents — practical, direct, no hype.',
+        'Articles on engineering with code agents: practical, direct, no hype.',
       emptyState: 'No published posts yet. Check back soon.',
       cardCta: 'Read post',
       homeCta: 'Read articles',
@@ -402,6 +402,17 @@ export function getHomeAlternateLinks(): AlternateLink[] {
       label: languages[lang].label,
     })),
     { lang: 'x-default' as const, href: getHomeHref(defaultLang) },
+  ];
+}
+
+export function getBlogIndexAlternateLinks(): AlternateLink[] {
+  return [
+    ...supportedLangs.map((lang) => ({
+      lang,
+      href: getBlogHref(lang),
+      label: languages[lang].label,
+    })),
+    { lang: 'x-default' as const, href: getBlogHref(defaultLang) },
   ];
 }
 

--- a/src/pages/en/blog/[slug].astro
+++ b/src/pages/en/blog/[slug].astro
@@ -1,0 +1,40 @@
+---
+import type { GetStaticPaths } from 'astro';
+import { render } from 'astro:content';
+import BlogPostLayout from '../../../layouts/BlogPostLayout.astro';
+import {
+  getPublishedPosts,
+  getBlogPostAlternateLinks,
+  type BlogEntry,
+} from '../../../lib/blog';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const posts = await getPublishedPosts('en');
+
+  return posts.map((post) => ({
+    params: { slug: post.data.slug },
+    props: { post },
+  }));
+};
+
+interface Props {
+  post: BlogEntry;
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+const alternateLinks = await getBlogPostAlternateLinks(post);
+---
+
+<BlogPostLayout
+  title={post.data.title}
+  slug={post.data.slug}
+  lang={post.data.lang}
+  description={post.data.description}
+  publishedAt={post.data.publishedAt}
+  updatedAt={post.data.updatedAt}
+  tags={post.data.tags}
+  alternateLinks={alternateLinks}
+>
+  <Content />
+</BlogPostLayout>

--- a/src/pages/en/blog/index.astro
+++ b/src/pages/en/blog/index.astro
@@ -1,21 +1,21 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import SectionBlock from '../../components/SectionBlock/SectionBlock.astro';
-import Grid from '../../components/Grid/Grid.astro';
-import Card from '../../components/Card/Card.astro';
-import Badge from '../../components/Badge/Badge.astro';
-import Footer from '../../components/Footer/Footer.astro';
-import Breadcrumbs from '../../components/Breadcrumbs/Breadcrumbs.astro';
-import { getPublishedPosts } from '../../lib/blog';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import SectionBlock from '../../../components/SectionBlock/SectionBlock.astro';
+import Grid from '../../../components/Grid/Grid.astro';
+import Card from '../../../components/Card/Card.astro';
+import Badge from '../../../components/Badge/Badge.astro';
+import Footer from '../../../components/Footer/Footer.astro';
+import Breadcrumbs from '../../../components/Breadcrumbs/Breadcrumbs.astro';
+import { getPublishedPosts } from '../../../lib/blog';
 import {
   languages,
   ui,
   getBlogHref,
   getHomeHref,
   getBlogIndexAlternateLinks,
-} from '../../lib/i18n';
+} from '../../../lib/i18n';
 
-const lang = 'pt-BR';
+const lang = 'en';
 const posts = await getPublishedPosts(lang);
 const labels = ui[lang].blog;
 

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -16,6 +16,7 @@ import {
   getHomeAlternateLinks,
   getSessionHref,
   getProjectHref,
+  getBlogHref,
   ui,
 } from '../../lib/i18n';
 
@@ -23,6 +24,7 @@ const lang = 'en';
 const sessions = getSessions(lang);
 const levelLabels = ui[lang].levels;
 const project = ui[lang].project;
+const blog = ui[lang].blog;
 
 function levelToBadgeVariant(level: string) {
   const map = {
@@ -97,6 +99,17 @@ function levelToLabel(level: string) {
           ))
         }
       </Grid>
+    </SectionBlock>
+
+    <SectionBlock padding="lg" id="blog">
+      <div class="project-cta-block">
+        <Badge variant="default">{blog.title}</Badge>
+        <h2>{blog.title}</h2>
+        <p>{blog.summary}</p>
+        <Button href={getBlogHref(lang)} size="lg">
+          {blog.homeCta}
+        </Button>
+      </div>
     </SectionBlock>
 
     <SectionBlock padding="xl" alt>


### PR DESCRIPTION
## Depends on #58–#64

Merge blog PRs **#58 → #64** into `main` first, then rebase this branch onto `main` and force-push. Until then, GitHub may show a large cumulative diff; the **phase 8-only delta** is ~291 lines (excl. `src/content/**`).

## Phase 8-only changes (after prerequisites)

- `src/lib/blog.ts` — alternate links / translation helpers
- `src/layouts/BlogPostLayout.astro` — translation UI
- EN blog routes under `src/pages/en/blog/`
- Footer `getBlogHref`, EN home `#blog`, i18n strings

## Content

EN post is in **#66** (separate PR).