### PR TITLE
content(blog): EN harness post

### DIFF
--- a/src/content/blog/harness-in-daily-work.md
+++ b/src/content/blog/harness-in-daily-work.md
@@ -1,0 +1,53 @@
+---
+title: 'Harness in daily work: what changes when you stop only prompting'
+slug: 'harness-in-daily-work'
+lang: 'en'
+description: 'Loose prompting ships code fast. Harness changes what happens next: context, limits, and validation before merge.'
+publishedAt: 2026-06-01
+draft: false
+translationKey: 'harness-daily-practice'
+tags: ['harness', 'agents', 'workflow']
+author: 'AI-Native Engineers'
+---
+
+You tell the agent "fix this bug" and two minutes later a clean diff shows up. It feels productive. Nobody asked whether it was the right bug, whether tests pass, or whether that file was allowed to change in the first place.
+
+**Stopping only prompting** does not mean stopping the conversation with the model. It means you stop treating every request as an island. Harness is the dry name for what wraps the chat: context the agent reads, rules for what it can do, and checks before you accept the result.
+
+## What changes in practice
+
+### For developers
+
+Before, the session ended when the code "made sense." Now you expect evidence: clean lint, passing build, scope aligned with what you asked. The agent still writes the patch. You still own the merge.
+
+The subtle shift: you are not reviewing syntax alone. You check whether the solution respects the phase plan, whether it refactored three modules without warning, whether it touched files that were out of scope. That sounds like bureaucracy until the first "creative" diff breaks production.
+
+### For PMs and QA
+
+You do not need to read code to feel the change. Questions that lived in your head move onto paper: what is done for this delivery? What is the acceptance criteria? What can the agent **not** do on its own?
+
+In practice, that becomes less "where is the feature?" and more "where is the test that proves the feature?" QA stops being only the last line of defense and becomes part of the contract before implementation starts.
+
+### For team leads
+
+The risk stops being only "the model hallucinated." It becomes "nobody documented what was decided." Harness pushes decisions into the repo: phase plan, validation checklist, small-commit policy. Chat conversation becomes an auditable trail.
+
+## Harness in one sentence (without turning into a lesson)
+
+**Harness** is the agent's work environment: context files, allowed tools, and validations that run before handoff. It does not replace human judgment. It reduces reliance on luck and memory.
+
+If you want the long version, with SDD (Spec-Driven Development) and flow design, the [maturity lesson](/en/sessions/maturity/) covers it as curriculum. This post is something else: what you feel on a Tuesday, in the tenth session of the month, when the team is past the "wow, it wrote React" phase.
+
+## Where it still breaks
+
+Bad harness becomes theater. Rules in the README nobody follows. Agent skills nobody invokes. Build passes but nobody reads the diff.
+
+Another blind spot: assuming infinite context fixes everything. Dumping the whole repo into the prompt is not harness. It is noise. Good context is curated: what matters for **this** task, not the company history.
+
+Models change. Tool categories (IDE with agent, coding agent CLI, cloud orchestrator) change too. The pattern that stays is simpler: clear intent, limited scope, explicit validation, human in the loop at merge.
+
+## Takeaway
+
+Loose prompting is great for exploration. Repeatable delivery asks for a system around the agent. Harness is not glamorous. It is what turns a demo into software you sign off on.
+
+If this resonated, start small: one commit rule, one build check, one phase plan before you ask for implementation. The rest scales later.

--- a/src/content/blog/harness-no-dia-a-dia.md
+++ b/src/content/blog/harness-no-dia-a-dia.md
@@ -5,6 +5,7 @@ lang: 'pt-BR'
 description: 'Prompt solto gera código rápido. Harness muda o que acontece depois: contexto, limites e validação antes do merge.'
 publishedAt: 2026-06-01
 draft: false
+translationKey: 'harness-daily-practice'
 tags: ['harness', 'agentes', 'workflow']
 author: 'AI-Native Engineers'
 ---


### PR DESCRIPTION
Adds harness-in-daily-work.md and translationKey on PT post. Merge #58–#65 first.

Made with [Cursor](https://cursor.com)