### PR TITLE
feat(blog): article Open Graph meta for posts (SEO leva 1)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,6 +16,10 @@ interface Props {
   title: string;
   description?: string;
   ogImage?: string;
+  ogType?: 'website' | 'article';
+  articlePublishedTime?: string;
+  articleModifiedTime?: string;
+  articleAuthor?: string;
   noindex?: boolean;
   lang?: Lang;
   alternateLinks?: AlternateLink[];
@@ -27,10 +31,16 @@ const {
   lang = 'pt-BR',
   description = ui[lang].siteDescription,
   ogImage,
+  ogType = 'website',
+  articlePublishedTime,
+  articleModifiedTime,
+  articleAuthor,
   noindex = false,
   alternateLinks = [],
   showHeader = true,
 } = Astro.props;
+
+const isArticle = ogType === 'article';
 
 const ogImageUrl = new URL(
   ogImage ?? `${import.meta.env.BASE_URL}og-default.png`,
@@ -194,8 +204,32 @@ const navDirectionScript = `
     />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={ogType} />
     <meta property="og:url" content={Astro.url.href} />
+    {
+      isArticle && articlePublishedTime && (
+        <>
+          <meta property="article:published_time" content={articlePublishedTime} />
+          <meta property="og:article:published_time" content={articlePublishedTime} />
+        </>
+      )
+    }
+    {
+      isArticle && articleModifiedTime && (
+        <>
+          <meta property="article:modified_time" content={articleModifiedTime} />
+          <meta property="og:article:modified_time" content={articleModifiedTime} />
+        </>
+      )
+    }
+    {
+      isArticle && articleAuthor && (
+        <>
+          <meta property="article:author" content={articleAuthor} />
+          <meta property="og:article:author" content={articleAuthor} />
+        </>
+      )
+    }
     <meta property="og:image" content={ogImageUrl} />
     <meta property="og:locale" content={languages[lang].locale} />
     <meta property="og:site_name" content="AI-Native Engineers" />

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -14,6 +14,7 @@ interface Props {
   description: string;
   publishedAt: Date;
   updatedAt?: Date;
+  author: string;
   tags: string[];
   alternateLinks?: AlternateLink[];
 }
@@ -24,6 +25,7 @@ const {
   description,
   publishedAt,
   updatedAt,
+  author,
   tags,
   alternateLinks = [],
 } = Astro.props;
@@ -55,6 +57,10 @@ const breadcrumbItems = [
   title={`${title} | AI-Native Engineers`}
   description={description}
   lang={lang}
+  ogType="article"
+  articlePublishedTime={publishedAt.toISOString()}
+  articleModifiedTime={updatedAt?.toISOString()}
+  articleAuthor={author}
   alternateLinks={alternateLinks}
 >
   <main id="main-content" class="blog-page">

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -29,6 +29,7 @@ const alternateLinks = await getBlogPostAlternateLinks(post);
   description={post.data.description}
   publishedAt={post.data.publishedAt}
   updatedAt={post.data.updatedAt}
+  author={post.data.author}
   tags={post.data.tags}
   alternateLinks={alternateLinks}
 >

--- a/src/pages/en/blog/[slug].astro
+++ b/src/pages/en/blog/[slug].astro
@@ -33,6 +33,7 @@ const alternateLinks = await getBlogPostAlternateLinks(post);
   description={post.data.description}
   publishedAt={post.data.publishedAt}
   updatedAt={post.data.updatedAt}
+  author={post.data.author}
   tags={post.data.tags}
   alternateLinks={alternateLinks}
 >


### PR DESCRIPTION
## Summary
SEO leva 1 (approved): blog **posts** use `og:type=article` plus `article:published_time` and `article:author` in `<head>`. Blog index and rest of site unchanged (`website`).

## Changes
- `BaseLayout`: optional `ogType`, article meta props (retrocompatible)
- `BlogPostLayout` + PT/EN `[slug]` routes: wire author and dates

## Test plan
- [x] `npm run lint` / `npm run build`
- [ ] Manager review before merge
- [ ] After deploy: View Source on `/blog/harness-no-dia-a-dia/` — `og:type=article`, article meta present
- [ ] `/blog/` index still `og:type=website`

## Note
**Do not merge until Bao approves.** Leva 2 (JSON-LD) and leva 3 (ogImage per post) out of scope.

Made with [Cursor](https://cursor.com)