### PR TITLE
feat: bilingual contact page (LinkedIn + email)

### DIFF
--- a/src/components/Contact/ContactPage.astro
+++ b/src/components/Contact/ContactPage.astro
@@ -1,0 +1,73 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Badge from '../Badge/Badge.astro';
+import Footer from '../Footer/Footer.astro';
+import SectionBlock from '../SectionBlock/SectionBlock.astro';
+import Breadcrumbs from '../Breadcrumbs/Breadcrumbs.astro';
+import {
+  getContactAlternateLinks,
+  getHomeHref,
+  ui,
+  type Lang,
+} from '../../lib/i18n';
+import { siteLinks } from '../../lib/siteLinks';
+import styles from './ContactPage.module.css';
+
+interface Props {
+  lang: Lang;
+}
+
+const { lang } = Astro.props;
+const labels = ui[lang].contact;
+const mailtoHref = `mailto:${siteLinks.author.email}`;
+
+const breadcrumbItems = [
+  { label: ui[lang].breadcrumb.home, href: getHomeHref(lang) },
+  { label: labels.breadcrumb },
+];
+---
+
+<BaseLayout
+  title={labels.title}
+  description={labels.description}
+  lang={lang}
+  alternateLinks={getContactAlternateLinks()}
+>
+  <main id="main-content">
+    <SectionBlock as="header" padding="xl">
+      <Breadcrumbs items={breadcrumbItems} lang={lang} />
+      <Badge variant="default">{labels.breadcrumb}</Badge>
+      <h1>{labels.heading}</h1>
+      <p class={styles.summary}>{labels.summary}</p>
+    </SectionBlock>
+
+    <SectionBlock padding="lg">
+      <ul class={styles.links}>
+        <li>
+          <a
+            class={styles.link}
+            href={siteLinks.author.linkedin}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={labels.linkedinAria}
+          >
+            <span class={styles.linkLabel}>{labels.linkedinLabel}</span>
+            <span class={styles.linkValue} aria-hidden="true">→</span>
+          </a>
+        </li>
+        <li>
+          <a
+            class={styles.link}
+            href={mailtoHref}
+            aria-label={labels.emailAria}
+          >
+            <span class={styles.linkLabel}>{labels.emailLabel}</span>
+            <span class={styles.linkValue}>{siteLinks.author.email}</span>
+          </a>
+        </li>
+      </ul>
+    </SectionBlock>
+
+    <Footer lang={lang} />
+  </main>
+</BaseLayout>

--- a/src/components/Contact/ContactPage.module.css
+++ b/src/components/Contact/ContactPage.module.css
@@ -1,0 +1,57 @@
+.summary {
+  margin-top: var(--space-md);
+  max-width: 42ch;
+  color: var(--color-text-muted);
+  line-height: var(--leading-relaxed);
+}
+
+.links {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  width: fit-content;
+  max-width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-heading);
+  font-weight: var(--weight-medium);
+  font-size: var(--text-base);
+  color: var(--color-primary);
+  text-decoration: none;
+  border: var(--border-thick);
+  box-shadow: var(--shadow-md);
+  background-color: var(--color-white);
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.link:hover {
+  background-color: var(--color-accent-2);
+  color: var(--color-fg-on-blue);
+  box-shadow: var(--shadow-lg);
+  transform: var(--motion-lift-sm);
+}
+
+.link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.linkLabel {
+  font-weight: var(--weight-bold);
+}
+
+.linkValue {
+  overflow-wrap: anywhere;
+}

--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -2,7 +2,7 @@
 import GitHubIcon from '../Icons/GitHubIcon.astro';
 import styles from './Footer.module.css';
 import type { Lang } from '../../lib/i18n';
-import { getBlogHref, ui } from '../../lib/i18n';
+import { getBlogHref, getContactHref, ui } from '../../lib/i18n';
 import { siteLinks } from '../../lib/siteLinks';
 
 interface Props {
@@ -11,6 +11,7 @@ interface Props {
 
 const { lang = 'pt-BR' } = Astro.props;
 const blogHref = getBlogHref(lang);
+const contactHref = getContactHref(lang);
 ---
 
 <!-- Phase 6 discovery: footer + home entry points to /blog/ (BLOG-ROADMAP) -->
@@ -27,6 +28,9 @@ const blogHref = getBlogHref(lang);
     </a>
     <a class={styles.navLink} href={blogHref}>
       {ui[lang].footer.blogLink}
+    </a>
+    <a class={styles.navLink} href={contactHref}>
+      {ui[lang].footer.contactLink}
     </a>
     <div class={styles.meta}>
       <span class={styles.copy}>AI-Native Engineers</span>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -178,6 +178,20 @@ export const ui = {
       personalSite: 'Site baltz.dev',
       repositoryLink: 'Repositório no GitHub',
       blogLink: 'Blog',
+      contactLink: 'Contato',
+    },
+    contact: {
+      title: 'Contato | AI-Native Engineers',
+      description:
+        'Fale com quem mantém o AI-Native Engineers — LinkedIn e email.',
+      breadcrumb: 'Contato',
+      heading: 'Contato',
+      summary:
+        'Dúvidas sobre o site, conteúdo ou colaboração? Escolha um canal abaixo.',
+      linkedinLabel: 'LinkedIn',
+      emailLabel: 'Email',
+      linkedinAria: 'Perfil no LinkedIn (abre em nova aba)',
+      emailAria: 'Enviar email',
     },
   },
   en: {
@@ -322,6 +336,20 @@ export const ui = {
       personalSite: 'baltz.dev website',
       repositoryLink: 'GitHub repository',
       blogLink: 'Blog',
+      contactLink: 'Contact',
+    },
+    contact: {
+      title: 'Contact | AI-Native Engineers',
+      description:
+        'Get in touch about AI-Native Engineers — LinkedIn and email.',
+      breadcrumb: 'Contact',
+      heading: 'Contact',
+      summary:
+        'Questions about the site, content, or collaboration? Pick a channel below.',
+      linkedinLabel: 'LinkedIn',
+      emailLabel: 'Email',
+      linkedinAria: 'LinkedIn profile (opens in a new tab)',
+      emailAria: 'Send email',
     },
   },
 } as const;
@@ -351,6 +379,27 @@ export function getBlogHref(lang: Lang, slug?: string): string {
   const prefix = lang === defaultLang ? '' : `${languages[lang].pathPrefix}/`;
   const base = `${prefix}blog`;
   return slug ? withBase(`${base}/${slug}`) : withBase(`${base}/`);
+}
+
+const contactSlugs: Record<Lang, string> = {
+  'pt-BR': 'contato',
+  en: 'contact',
+};
+
+export function getContactHref(lang: Lang): string {
+  const prefix = lang === defaultLang ? '' : `${languages[lang].pathPrefix}/`;
+  return withBase(`${prefix}${contactSlugs[lang]}/`);
+}
+
+export function getContactAlternateLinks(): AlternateLink[] {
+  return [
+    ...supportedLangs.map((lang) => ({
+      lang,
+      href: getContactHref(lang),
+      label: languages[lang].label,
+    })),
+    { lang: 'x-default' as const, href: getContactHref(defaultLang) },
+  ];
 }
 
 const projectSlugs: Record<Lang, string> = {

--- a/src/lib/siteLinks.ts
+++ b/src/lib/siteLinks.ts
@@ -1,4 +1,8 @@
 export const siteLinks = {
   repository: 'https://github.com/baltazarparra/ai-native-engineering',
   baltz: 'https://baltz.dev',
+  author: {
+    linkedin: 'https://linkedin.com/in/pachicodes',
+    email: 'pachicodes@gmail.com',
+  },
 } as const;

--- a/src/pages/contato.astro
+++ b/src/pages/contato.astro
@@ -1,0 +1,5 @@
+---
+import ContactPage from '../components/Contact/ContactPage.astro';
+---
+
+<ContactPage lang="pt-BR" />

--- a/src/pages/en/contact.astro
+++ b/src/pages/en/contact.astro
@@ -1,0 +1,5 @@
+---
+import ContactPage from '../../components/Contact/ContactPage.astro';
+---
+
+<ContactPage lang="en" />


### PR DESCRIPTION
## Summary
Contact page for Pachi (contributor): LinkedIn + `pachicodes@gmail.com`, PT `/contato/` and EN `/en/contact/`, footer link.

## Test plan
- [x] `npm run lint` / `npm run build` (48 pages)
- [ ] Manager review **before merge**
- [ ] `/contato/` and `/en/contact/` — links work
- [ ] Footer shows Contato / Contact
- [ ] Confirm LinkedIn URL: `https://linkedin.com/in/pachicodes` (update if wrong)

## Note
**Do not merge until approved.** Separate from PR #68 (blog SEO).

Made with [Cursor](https://cursor.com)